### PR TITLE
Handle v3 EOF message on empty payload

### DIFF
--- a/yaml.go
+++ b/yaml.go
@@ -11,6 +11,7 @@ package yaml // import "github.com/invopop/yaml"
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"reflect"
@@ -113,7 +114,11 @@ func yamlToJSON(dec *yaml.Decoder, jsonTarget *reflect.Value) ([]byte, error) {
 	// Convert the YAML to an object.
 	var yamlObj interface{}
 	if err := dec.Decode(&yamlObj); err != nil {
-		return nil, err
+		// Functionality changed in v3 which means we need to ignore EOF error.
+		// See https://github.com/go-yaml/yaml/issues/639
+		if !errors.Is(err, io.EOF) {
+			return nil, err
+		}
 	}
 
 	// YAML objects are not completely compatible with JSON objects (e.g. you

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -61,9 +61,19 @@ type NestedSlice struct {
 }
 
 func TestUnmarshal(t *testing.T) {
-	y := []byte("a: 1")
+	y := []byte(``)
 	s1 := UnmarshalString{}
-	e1 := UnmarshalString{A: "1"}
+	e1 := UnmarshalString{}
+	unmarshalEqual(t, y, &s1, &e1)
+
+	y = []byte(`{}`)
+	s1 = UnmarshalString{}
+	e1 = UnmarshalString{}
+	unmarshalEqual(t, y, &s1, &e1)
+
+	y = []byte("a: 1")
+	s1 = UnmarshalString{}
+	e1 = UnmarshalString{A: "1"}
 	unmarshalEqual(t, y, &s1, &e1)
 
 	y = []byte(`a: "1"`)


### PR DESCRIPTION
This PR hides the unexpected `io.EOF` error message introduced by the `NewDecoder` interface in yaml.v3. An empty data source should not raise an error when using the standard `Unmarshal` method.

More details on this here: https://github.com/go-yaml/yaml/issues/639