### PR TITLE
fix: handle map[interface{}]interface{} in extractOrigins + update for file-at-index-0 format

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 ## Fork
 This fork is an improved version of the invopop/yaml package, designed to include line and column location information for YAML elements during unmarshalling.  
 To include location information use ```UnmarshalWithOrigin``` instead of ```Unmarshal```.  
-The heavy lifting is done by the underlying oasdiff/yaml3 package.
+The heavy lifting is done by the underlying [oasdiff/yaml3](https://github.com/oasdiff/yaml3) package.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,11 @@
 [![Go Report Card](https://goreportcard.com/badge/github.com/invopop/yaml)](https://goreportcard.com/report/github.com/invopop/yaml)
 ![Latest Tag](https://img.shields.io/github/v/tag/invopop/yaml)
 
+## Fork
+This fork is an improved version of the invopop/yaml package, designed to include line and column location information for YAML elements during unmarshalling.  
+To include location information use ```UnmarshalWithOrigin``` instead of ```Unmarshal```.  
+The heavy lifting is done by the underlying oasdiff/yaml3 package.
+
 ## Introduction
 
 A wrapper around [go-yaml](https://github.com/go-yaml/yaml) designed to enable a better way of handling YAML when marshaling to and from structs.

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
-module github.com/invopop/yaml
+module github.com/oasdiff/yaml
 
 go 1.22.5
 
-replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240920135353-c185dc6ea7c6
-
-require gopkg.in/yaml.v3 v3.0.0
+require github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349
+require github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90
+require github.com/oasdiff/yaml3 v0.0.0-20260217201013-8a620da6102a

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,5 @@
 module github.com/invopop/yaml
 
-go 1.14
+go 1.22.5
 
-require gopkg.in/yaml.v3 v3.0.1
+require oasdiff/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -4,4 +4,4 @@ go 1.22.5
 
 replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08
 
-require github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08
+require gopkg.in/yaml.v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
-module github.com/invopop/yaml
+module github.com/oasdiff/yaml
 
 go 1.22.5
 
-replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240816154714-050c8afd23bb
+replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08
 
-require gopkg.in/yaml.v3 v3.0.1
+require github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/invopop/yaml
 
 go 1.22.5
 
-replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240819204501-233901bce7fe
+replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240920115456-22b7153ed9a8
 
 require gopkg.in/yaml.v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,6 @@ module github.com/invopop/yaml
 
 go 1.22.5
 
-replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240920115456-22b7153ed9a8
+replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240920135353-c185dc6ea7c6
 
 require gopkg.in/yaml.v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
-module github.com/oasdiff/yaml
+module github.com/invopop/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08
+replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240819204501-233901bce7fe
+
+require gopkg.in/yaml.v3 v3.0.0

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,6 @@ module github.com/invopop/yaml
 
 go 1.22.5
 
-require oasdiff/yaml.v3 v3.0.1
+replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240816154714-050c8afd23bb
+
+require gopkg.in/yaml.v3 v3.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-replace gopkg.in/yaml.v3 => github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08
-
-require gopkg.in/yaml.v3 v3.0.0
+require github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20260316
+require github.com/oasdiff/yaml3 v0.0.1

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091
+require github.com/oasdiff/yaml3 v0.0.0-20260316

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.2
+require github.com/oasdiff/yaml3 v0.0.3

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20260218210655-d948faea3f9a
+require github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20260217201013-8a620da6102a
+require github.com/oasdiff/yaml3 v0.0.0-20260218210655-d948faea3f9a

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.1
+require github.com/oasdiff/yaml3 v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.3
+require github.com/oasdiff/yaml3 v0.0.4

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/oasdiff/yaml
 
 go 1.22.5
 
-require github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b
+require github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20240920135353-c185dc6ea7c6 h1:+ZsuDTdapTJxfMQk7SOJiNMg0v36pui01L7FEO615r8=
-github.com/oasdiff/yaml3 v0.0.0-20240920135353-c185dc6ea7c6/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
+github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349 h1:t05Ww3DxZutOqbMN+7OIuqDwXbhl32HiZGpLy26BAPc=
+github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
-github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20260217201013-8a620da6102a h1:so9gdCU1AyG+EFCCp6ORLut4MBi/wIh4J3jGrEjNZnI=
+github.com/oasdiff/yaml3 v0.0.0-20260217201013-8a620da6102a/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349 h1:t05Ww3DxZutOqbMN+7OIuqDwXbhl32HiZGpLy26BAPc=
-github.com/oasdiff/yaml3 v0.0.0-20241210130736-a94c01f36349/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 h1:bQx3WeLcUWy+RletIKwUIt4x3t8n2SxavmoclizMb8c=
+github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,2 @@
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
-gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20240819204501-233901bce7fe h1:sHb5QDQFoFYvM+Ebq0Bo2JC27+U8oHM8Mm50oBwBtnQ=
-github.com/oasdiff/yaml3 v0.0.0-20240819204501-233901bce7fe/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
+github.com/oasdiff/yaml3 v0.0.0-20240920115456-22b7153ed9a8 h1:VBLtVNLO2m0QwtxnsHJxf+SagBDx1VZepMPJbJBdwdI=
+github.com/oasdiff/yaml3 v0.0.0-20240920115456-22b7153ed9a8/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/oasdiff/yaml3 v0.0.0-20240816154714-050c8afd23bb h1:0hIUy/Ay52Tbr/NNnn81OIAoi5u4U0TiRiEdTrT6Zg8=
+github.com/oasdiff/yaml3 v0.0.0-20240816154714-050c8afd23bb/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20240920115456-22b7153ed9a8 h1:VBLtVNLO2m0QwtxnsHJxf+SagBDx1VZepMPJbJBdwdI=
-github.com/oasdiff/yaml3 v0.0.0-20240920115456-22b7153ed9a8/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
+github.com/oasdiff/yaml3 v0.0.0-20240920135353-c185dc6ea7c6 h1:+ZsuDTdapTJxfMQk7SOJiNMg0v36pui01L7FEO615r8=
+github.com/oasdiff/yaml3 v0.0.0-20240920135353-c185dc6ea7c6/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20240816154714-050c8afd23bb h1:0hIUy/Ay52Tbr/NNnn81OIAoi5u4U0TiRiEdTrT6Zg8=
-github.com/oasdiff/yaml3 v0.0.0-20240816154714-050c8afd23bb/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
+github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08 h1:46U2uP/pxdhPwrP7m28Q+A36pl5zTSdBsTd//B5lqD0=
+github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08 h1:46U2uP/pxdhPwrP7m28Q+A36pl5zTSdBsTd//B5lqD0=
-github.com/oasdiff/yaml3 v0.0.0-20240818072818-815e522e3d08/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20240819204501-233901bce7fe h1:sHb5QDQFoFYvM+Ebq0Bo2JC27+U8oHM8Mm50oBwBtnQ=
+github.com/oasdiff/yaml3 v0.0.0-20240819204501-233901bce7fe/go.mod h1:lqlOfJRrYpgeWHQj+ky2tf7UJ3PzgHTHRQEpc90nbp0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20260316 h1:E5kcP7Xtg0l1RfDqAAFbNpwQf4AvRFq75LOlFDEg28g=
-github.com/oasdiff/yaml3 v0.0.0-20260316/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.1 h1:kReOSraQLTxuuGNX9aNeJ7tcsvUB2MS+iupdUrWe4Z0=
+github.com/oasdiff/yaml3 v0.0.1/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,6 @@
 github.com/oasdiff/yaml3 v0.0.2 h1:KAbH+Qi4aT7PQbG4AASP25Yob3u+VyAVjLrTHaR/FOE=
 github.com/oasdiff/yaml3 v0.0.2/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.3 h1:AoDWNMgx8ND5gmaxeUSX4LjrlxrYB6CGzKdVi/1zAPQ=
+github.com/oasdiff/yaml3 v0.0.3/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20260218210655-d948faea3f9a h1:GJqDDMVzCsld3oF8oRNfQwtQ5BqmXyUx0c59bSfrgzI=
-github.com/oasdiff/yaml3 v0.0.0-20260218210655-d948faea3f9a/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b h1:vivRhVUAa9t1q0Db4ZmezBP8pWQWnXHFokZj0AOea2g=
+github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091 h1:9BhI2ddVLDF7hbq1NZNF7jZDjRGxBzLLCrpw349pV6o=
-github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20260316 h1:E5kcP7Xtg0l1RfDqAAFbNpwQf4AvRFq75LOlFDEg28g=
+github.com/oasdiff/yaml3 v0.0.0-20260316/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20260217201013-8a620da6102a h1:so9gdCU1AyG+EFCCp6ORLut4MBi/wIh4J3jGrEjNZnI=
-github.com/oasdiff/yaml3 v0.0.0-20260217201013-8a620da6102a/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20260218210655-d948faea3f9a h1:GJqDDMVzCsld3oF8oRNfQwtQ5BqmXyUx0c59bSfrgzI=
+github.com/oasdiff/yaml3 v0.0.0-20260218210655-d948faea3f9a/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.1 h1:kReOSraQLTxuuGNX9aNeJ7tcsvUB2MS+iupdUrWe4Z0=
-github.com/oasdiff/yaml3 v0.0.1/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.2 h1:KAbH+Qi4aT7PQbG4AASP25Yob3u+VyAVjLrTHaR/FOE=
+github.com/oasdiff/yaml3 v0.0.2/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b h1:vivRhVUAa9t1q0Db4ZmezBP8pWQWnXHFokZj0AOea2g=
-github.com/oasdiff/yaml3 v0.0.0-20260224194419-61cd415a242b/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091 h1:9BhI2ddVLDF7hbq1NZNF7jZDjRGxBzLLCrpw349pV6o=
+github.com/oasdiff/yaml3 v0.0.0-20260316155952-42d24df7b091/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,4 @@
-github.com/oasdiff/yaml3 v0.0.2 h1:KAbH+Qi4aT7PQbG4AASP25Yob3u+VyAVjLrTHaR/FOE=
-github.com/oasdiff/yaml3 v0.0.2/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
-github.com/oasdiff/yaml3 v0.0.3 h1:AoDWNMgx8ND5gmaxeUSX4LjrlxrYB6CGzKdVi/1zAPQ=
-github.com/oasdiff/yaml3 v0.0.3/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
+github.com/oasdiff/yaml3 v0.0.4 h1:U5RTQZpBmsbcyCFlzPVuMctk6Jme6lOrbl0jJoOovMw=
+github.com/oasdiff/yaml3 v0.0.4/go.mod h1:y5+oSEHCPT/DGrS++Wc/479ERge0zTFxaF8PbGKcg2o=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/yaml.go
+++ b/yaml.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	"github.com/oasdiff/yaml3"
 )
 
 // Marshal the object into JSON then converts JSON to YAML and returns the

--- a/yaml.go
+++ b/yaml.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/oasdiff/yaml3"
+	yaml "github.com/oasdiff/yaml3"
 )
 
 // Marshal the object into JSON then converts JSON to YAML and returns the
@@ -44,14 +44,14 @@ type YAMLOpt func(*yaml.Decoder) *yaml.Decoder
 // Unmarshal converts YAML to JSON then uses JSON to unmarshal into an object,
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
-	return UnmarshalWithOrigin(y, o, false, opts...)
+	return UnmarshalWithOrigin(y, o, false, "", opts...)
 }
 
 // UnmarshalWithOrigin is like Unmarshal but if withOrigin is true, it will
 // include the origin information in the output.
-func UnmarshalWithOrigin(y []byte, o interface{}, withOrigin bool, opts ...JSONOpt) error {
+func UnmarshalWithOrigin(y []byte, o interface{}, withOrigin bool, file string, opts ...JSONOpt) error {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
-	dec.Origin(withOrigin)
+	dec.Origin(withOrigin, file)
 	return unmarshal(dec, o, opts)
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"strconv"
 
-	yaml "github.com/oasdiff/yaml3"
+	"gopkg.in/yaml.v3"
 )
 
 // Marshal the object into JSON then converts JSON to YAML and returns the

--- a/yaml.go
+++ b/yaml.go
@@ -16,7 +16,7 @@ import (
 	"reflect"
 	"strconv"
 
-	"gopkg.in/yaml.v3"
+	yaml "github.com/oasdiff/yaml3"
 )
 
 // Marshal the object into JSON then converts JSON to YAML and returns the
@@ -52,7 +52,7 @@ func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 // to the output.
 func UnmarshalWithLocation(y []byte, o interface{}, opts ...JSONOpt) error {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
-	dec.Location(true)
+	dec.Origin(true)
 	return unmarshal(dec, o, opts)
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -48,9 +48,9 @@ func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 	return unmarshal(dec, o, opts)
 }
 
-// UnmarshalWithLocation is like Unmarshal but it also adds location information
+// UnmarshalWithOrigin is like Unmarshal but it also adds location information
 // to the output.
-func UnmarshalWithLocation(y []byte, o interface{}, opts ...JSONOpt) error {
+func UnmarshalWithOrigin(y []byte, o interface{}, opts ...JSONOpt) error {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
 	dec.Origin(true)
 	return unmarshal(dec, o, opts)

--- a/yaml.go
+++ b/yaml.go
@@ -44,15 +44,14 @@ type YAMLOpt func(*yaml.Decoder) *yaml.Decoder
 // Unmarshal converts YAML to JSON then uses JSON to unmarshal into an object,
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
-	dec := yaml.NewDecoder(bytes.NewReader(y))
-	return unmarshal(dec, o, opts)
+	return UnmarshalWithOrigin(y, o, false, opts...)
 }
 
-// UnmarshalWithOrigin is like Unmarshal but it also adds location information
-// to the output.
-func UnmarshalWithOrigin(y []byte, o interface{}, opts ...JSONOpt) error {
+// UnmarshalWithOrigin is like Unmarshal but if withOrigin is true, it will
+// include the origin information in the output.
+func UnmarshalWithOrigin(y []byte, o interface{}, withOrigin bool, opts ...JSONOpt) error {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
-	dec.Origin(true)
+	dec.Origin(withOrigin)
 	return unmarshal(dec, o, opts)
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -38,10 +38,21 @@ func Marshal(o interface{}) ([]byte, error) {
 // JSONOpt is a decoding option for decoding from JSON format.
 type JSONOpt func(*json.Decoder) *json.Decoder
 
+// YAMLOpt is a decoding option for decoding from YAML format.
+type YAMLOpt func(*yaml.Decoder) *yaml.Decoder
+
 // Unmarshal converts YAML to JSON then uses JSON to unmarshal into an object,
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
+	return unmarshal(dec, o, opts)
+}
+
+// UnmarshalWithLocation is like Unmarshal but it also adds location information
+// to the output.
+func UnmarshalWithLocation(y []byte, o interface{}, opts ...JSONOpt) error {
+	dec := yaml.NewDecoder(bytes.NewReader(y))
+	dec.Location(true)
 	return unmarshal(dec, o, opts)
 }
 

--- a/yaml.go
+++ b/yaml.go
@@ -65,7 +65,12 @@ func UnmarshalWithOrigin(y []byte, o interface{}, origin OriginOpt, opts ...JSON
 // It mirrors the structure of the spec: Fields tracks map children by key,
 // Items tracks slice children by index.
 type OriginTree struct {
-	// Origin is the raw __origin__ value (map[string]any) for this node.
+	// File is the source file for all origins in this subtree.
+	// Set once at the root of each decode call; all nodes in the same
+	// decode share the same file.
+	File string
+	// Origin is the raw __origin__ value ([]any compact sequence) for this node.
+	// Format: [key_name, key_line, key_col, nf, f1_name, f1_delta, f1_col, ..., ns, ...]
 	Origin any
 	// Fields holds child trees keyed by map key name.
 	Fields map[string]*OriginTree
@@ -92,7 +97,7 @@ func UnmarshalWithOriginTree(y []byte, o interface{}, origin OriginOpt, opts ...
 	// Extract __origin__ before JSON conversion so the JSON stays small.
 	var tree *OriginTree
 	if origin.Enabled {
-		tree = extractOrigins(yamlObj)
+		tree = extractOrigins(yamlObj, origin.File)
 	}
 
 	// Convert to JSON (without __origin__) and unmarshal into the target struct.
@@ -116,20 +121,28 @@ const originKey = "__origin__"
 
 // extractOrigins recursively extracts and removes __origin__ entries from a
 // YAML-decoded map tree, returning the origin data as an OriginTree.
-func extractOrigins(v any) *OriginTree {
+// file is the source file for all nodes in this decode call.
+func extractOrigins(v any, file string) *OriginTree {
 	switch val := v.(type) {
 	case map[string]any:
-		tree := &OriginTree{}
+		return extractOriginsFromStringMap(val, file)
+	case map[interface{}]interface{}:
+		// yaml3 produces map[interface{}]interface{} when map keys are non-string
+		// (e.g. integer HTTP status codes like 200). __origin__ is always a string
+		// key, so we must handle this case to strip it from mixed-key maps.
+		tree := &OriginTree{File: file}
 		if orig, ok := val[originKey]; ok {
 			tree.Origin = orig
 			delete(val, originKey)
 		}
 		for k, child := range val {
-			if childTree := extractOrigins(child); childTree != nil {
+			if childTree := extractOrigins(child, file); childTree != nil {
 				if tree.Fields == nil {
 					tree.Fields = make(map[string]*OriginTree)
 				}
-				tree.Fields[k] = childTree
+				if ks, ok := k.(string); ok {
+					tree.Fields[ks] = childTree
+				}
 			}
 		}
 		if tree.Origin == nil && tree.Fields == nil {
@@ -140,7 +153,7 @@ func extractOrigins(v any) *OriginTree {
 		var items []*OriginTree
 		hasChild := false
 		for _, child := range val {
-			childTree := extractOrigins(child)
+			childTree := extractOrigins(child, file)
 			items = append(items, childTree) // may be nil; preserves index alignment
 			if childTree != nil {
 				hasChild = true
@@ -149,10 +162,30 @@ func extractOrigins(v any) *OriginTree {
 		if !hasChild {
 			return nil
 		}
-		return &OriginTree{Items: items}
+		return &OriginTree{File: file, Items: items}
 	default:
 		return nil
 	}
+}
+
+func extractOriginsFromStringMap(val map[string]any, file string) *OriginTree {
+	tree := &OriginTree{File: file}
+	if orig, ok := val[originKey]; ok {
+		tree.Origin = orig
+		delete(val, originKey)
+	}
+	for k, child := range val {
+		if childTree := extractOrigins(child, file); childTree != nil {
+			if tree.Fields == nil {
+				tree.Fields = make(map[string]*OriginTree)
+			}
+			tree.Fields[k] = childTree
+		}
+	}
+	if tree.Origin == nil && tree.Fields == nil {
+		return nil
+	}
+	return tree
 }
 
 func unmarshal(dec *yaml.Decoder, o interface{}, opts []JSONOpt) error {

--- a/yaml.go
+++ b/yaml.go
@@ -44,14 +44,21 @@ type YAMLOpt func(*yaml.Decoder) *yaml.Decoder
 // Unmarshal converts YAML to JSON then uses JSON to unmarshal into an object,
 // optionally configuring the behavior of the JSON unmarshal.
 func Unmarshal(y []byte, o interface{}, opts ...JSONOpt) error {
-	return UnmarshalWithOrigin(y, o, false, "", opts...)
+	return UnmarshalWithOrigin(y, o, OriginOpt{}, opts...)
 }
 
-// UnmarshalWithOrigin is like Unmarshal but if withOrigin is true, it will
-// include the origin information in the output.
-func UnmarshalWithOrigin(y []byte, o interface{}, withOrigin bool, file string, opts ...JSONOpt) error {
+// OriginOpt controls origin-tracking behavior in UnmarshalWithOrigin.
+type OriginOpt struct {
+	// Enabled adds __origin__ metadata to maps during unmarshaling.
+	Enabled bool
+	// File is the source file name recorded in origin metadata.
+	File string
+}
+
+// UnmarshalWithOrigin is like Unmarshal but supports origin tracking via OriginOpt.
+func UnmarshalWithOrigin(y []byte, o interface{}, origin OriginOpt, opts ...JSONOpt) error {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
-	dec.Origin(withOrigin, file)
+	dec.Origin(origin.Enabled, origin.File)
 	return unmarshal(dec, o, opts)
 }
 
@@ -142,6 +149,7 @@ func yamlToJSON(dec *yaml.Decoder, jsonTarget *reflect.Value) ([]byte, error) {
 	return json.Marshal(jsonObj)
 }
 
+// convertToJSONableObject converts a YAML object to a JSON-compatible object.
 func convertToJSONableObject(yamlObj interface{}, jsonTarget *reflect.Value) (interface{}, error) { //nolint:gocyclo
 	var err error
 

--- a/yaml.go
+++ b/yaml.go
@@ -57,9 +57,102 @@ type OriginOpt struct {
 
 // UnmarshalWithOrigin is like Unmarshal but supports origin tracking via OriginOpt.
 func UnmarshalWithOrigin(y []byte, o interface{}, origin OriginOpt, opts ...JSONOpt) error {
+	_, err := UnmarshalWithOriginTree(y, o, origin, opts...)
+	return err
+}
+
+// OriginTree holds __origin__ data extracted from a YAML-decoded map tree.
+// It mirrors the structure of the spec: Fields tracks map children by key,
+// Items tracks slice children by index.
+type OriginTree struct {
+	// Origin is the raw __origin__ value (map[string]any) for this node.
+	Origin any
+	// Fields holds child trees keyed by map key name.
+	Fields map[string]*OriginTree
+	// Items holds child trees for slice elements (index-aligned).
+	Items []*OriginTree
+}
+
+// UnmarshalWithOriginTree is like UnmarshalWithOrigin but strips __origin__
+// from the intermediate map before JSON conversion and returns the extracted
+// origin data as an OriginTree. The caller can apply the tree to Go structs
+// after unmarshaling. When origin tracking is disabled, the returned tree is nil.
+func UnmarshalWithOriginTree(y []byte, o interface{}, origin OriginOpt, opts ...JSONOpt) (*OriginTree, error) {
 	dec := yaml.NewDecoder(bytes.NewReader(y))
 	dec.Origin(origin.Enabled, origin.File)
-	return unmarshal(dec, o, opts)
+
+	// Decode YAML into a generic object.
+	var yamlObj interface{}
+	if err := dec.Decode(&yamlObj); err != nil {
+		if !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("error converting YAML to JSON: %v", err)
+		}
+	}
+
+	// Extract __origin__ before JSON conversion so the JSON stays small.
+	var tree *OriginTree
+	if origin.Enabled {
+		tree = extractOrigins(yamlObj)
+	}
+
+	// Convert to JSON (without __origin__) and unmarshal into the target struct.
+	vo := reflect.ValueOf(o)
+	jsonObj, err := convertToJSONableObject(yamlObj, &vo)
+	if err != nil {
+		return nil, fmt.Errorf("error converting YAML to JSON: %v", err)
+	}
+	j, err := json.Marshal(jsonObj)
+	if err != nil {
+		return nil, fmt.Errorf("error converting YAML to JSON: %v", err)
+	}
+	if err := jsonUnmarshal(bytes.NewReader(j), o, opts...); err != nil {
+		return nil, fmt.Errorf("error unmarshaling JSON: %v", err)
+	}
+
+	return tree, nil
+}
+
+const originKey = "__origin__"
+
+// extractOrigins recursively extracts and removes __origin__ entries from a
+// YAML-decoded map tree, returning the origin data as an OriginTree.
+func extractOrigins(v any) *OriginTree {
+	switch val := v.(type) {
+	case map[string]any:
+		tree := &OriginTree{}
+		if orig, ok := val[originKey]; ok {
+			tree.Origin = orig
+			delete(val, originKey)
+		}
+		for k, child := range val {
+			if childTree := extractOrigins(child); childTree != nil {
+				if tree.Fields == nil {
+					tree.Fields = make(map[string]*OriginTree)
+				}
+				tree.Fields[k] = childTree
+			}
+		}
+		if tree.Origin == nil && tree.Fields == nil {
+			return nil
+		}
+		return tree
+	case []any:
+		var items []*OriginTree
+		hasChild := false
+		for _, child := range val {
+			childTree := extractOrigins(child)
+			items = append(items, childTree) // may be nil; preserves index alignment
+			if childTree != nil {
+				hasChild = true
+			}
+		}
+		if !hasChild {
+			return nil
+		}
+		return &OriginTree{Items: items}
+	default:
+		return nil
+	}
 }
 
 func unmarshal(dec *yaml.Decoder, o interface{}, opts []JSONOpt) error {

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -406,3 +406,156 @@ func TestYAMLToJSONDuplicateFields(t *testing.T) {
 		t.Error("expected YAMLtoJSON to fail on duplicate field names")
 	}
 }
+
+func TestExtractOrigins_Map(t *testing.T) {
+	input := map[string]any{
+		"__origin__": map[string]any{"key": "root"},
+		"info": map[string]any{
+			"__origin__": map[string]any{"key": "info"},
+			"title":      "Test",
+		},
+	}
+
+	tree := extractOrigins(input)
+	if tree == nil {
+		t.Fatal("expected non-nil tree")
+	}
+
+	// Root origin extracted
+	if tree.Origin == nil {
+		t.Fatal("expected root origin")
+	}
+	if tree.Origin.(map[string]any)["key"] != "root" {
+		t.Error("wrong root origin")
+	}
+
+	// __origin__ removed from map
+	if _, ok := input["__origin__"]; ok {
+		t.Error("__origin__ not removed from root map")
+	}
+	infoMap := input["info"].(map[string]any)
+	if _, ok := infoMap["__origin__"]; ok {
+		t.Error("__origin__ not removed from info map")
+	}
+
+	// Child tree extracted
+	infoTree := tree.Fields["info"]
+	if infoTree == nil {
+		t.Fatal("expected info child tree")
+	}
+	if infoTree.Origin.(map[string]any)["key"] != "info" {
+		t.Error("wrong info origin")
+	}
+}
+
+func TestExtractOrigins_Slice(t *testing.T) {
+	input := map[string]any{
+		"items": []any{
+			map[string]any{
+				"__origin__": map[string]any{"key": "item0"},
+				"name":       "first",
+			},
+			"scalar",
+			map[string]any{
+				"__origin__": map[string]any{"key": "item2"},
+				"name":       "third",
+			},
+		},
+	}
+
+	tree := extractOrigins(input)
+	if tree == nil {
+		t.Fatal("expected non-nil tree")
+	}
+
+	itemsTree := tree.Fields["items"]
+	if itemsTree == nil {
+		t.Fatal("expected items child tree")
+	}
+	if len(itemsTree.Items) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(itemsTree.Items))
+	}
+	if itemsTree.Items[0] == nil || itemsTree.Items[0].Origin == nil {
+		t.Error("expected origin for item 0")
+	}
+	if itemsTree.Items[1] != nil {
+		t.Error("expected nil tree for scalar item 1")
+	}
+	if itemsTree.Items[2] == nil || itemsTree.Items[2].Origin == nil {
+		t.Error("expected origin for item 2")
+	}
+
+	// __origin__ removed from slice elements
+	item0 := input["items"].([]any)[0].(map[string]any)
+	if _, ok := item0["__origin__"]; ok {
+		t.Error("__origin__ not removed from item 0")
+	}
+}
+
+func TestExtractOrigins_Nil(t *testing.T) {
+	tree := extractOrigins("scalar")
+	if tree != nil {
+		t.Error("expected nil tree for scalar")
+	}
+
+	tree = extractOrigins(map[string]any{"a": "b"})
+	if tree != nil {
+		t.Error("expected nil tree for map without __origin__")
+	}
+}
+
+type OriginTreeTestStruct struct {
+	Info struct {
+		Title   string `json:"title"`
+		Version string `json:"version"`
+	} `json:"info"`
+}
+
+func TestUnmarshalWithOriginTree(t *testing.T) {
+	yamlData := []byte("info:\n  title: Test\n  version: v1\n")
+
+	var out OriginTreeTestStruct
+	tree, err := UnmarshalWithOriginTree(yamlData, &out, OriginOpt{Enabled: true, File: "test.yaml"})
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+
+	// Struct populated correctly
+	if out.Info.Title != "Test" {
+		t.Errorf("expected title Test, got %s", out.Info.Title)
+	}
+
+	// Origin tree returned (root mapping has no __origin__, but info does)
+	if tree == nil {
+		t.Fatal("expected non-nil origin tree")
+	}
+
+	// Info subtree with origin
+	infoTree := tree.Fields["info"]
+	if infoTree == nil {
+		t.Fatal("expected info subtree")
+	}
+	if infoTree.Origin == nil {
+		t.Fatal("expected info origin")
+	}
+	originMap := infoTree.Origin.(map[string]any)
+	if originMap["key"] == nil {
+		t.Error("expected key in info origin")
+	}
+}
+
+func TestUnmarshalWithOriginTree_Disabled(t *testing.T) {
+	yamlData := []byte("info:\n  title: Test\n")
+
+	var out OriginTreeTestStruct
+	tree, err := UnmarshalWithOriginTree(yamlData, &out, OriginOpt{Enabled: false})
+	if err != nil {
+		t.Fatalf("unmarshal error: %v", err)
+	}
+	if tree != nil {
+		t.Error("expected nil tree when origin is disabled")
+	}
+	if out.Info.Title != "Test" {
+		t.Errorf("expected title Test, got %s", out.Info.Title)
+	}
+}

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -416,7 +416,7 @@ func TestExtractOrigins_Map(t *testing.T) {
 		},
 	}
 
-	tree := extractOrigins(input)
+	tree := extractOrigins(input, "")
 	if tree == nil {
 		t.Fatal("expected non-nil tree")
 	}
@@ -463,7 +463,7 @@ func TestExtractOrigins_Slice(t *testing.T) {
 		},
 	}
 
-	tree := extractOrigins(input)
+	tree := extractOrigins(input, "")
 	if tree == nil {
 		t.Fatal("expected non-nil tree")
 	}
@@ -493,12 +493,12 @@ func TestExtractOrigins_Slice(t *testing.T) {
 }
 
 func TestExtractOrigins_Nil(t *testing.T) {
-	tree := extractOrigins("scalar")
+	tree := extractOrigins("scalar", "")
 	if tree != nil {
 		t.Error("expected nil tree for scalar")
 	}
 
-	tree = extractOrigins(map[string]any{"a": "b"})
+	tree = extractOrigins(map[string]any{"a": "b"}, "")
 	if tree != nil {
 		t.Error("expected nil tree for map without __origin__")
 	}
@@ -538,9 +538,16 @@ func TestUnmarshalWithOriginTree(t *testing.T) {
 	if infoTree.Origin == nil {
 		t.Fatal("expected info origin")
 	}
-	originMap := infoTree.Origin.(map[string]any)
-	if originMap["key"] == nil {
-		t.Error("expected key in info origin")
+	// New compact format: []any{key_name, key_line, key_col, nf, ...}
+	originSeq, ok := infoTree.Origin.([]any)
+	if !ok {
+		t.Fatalf("expected []any origin, got %T", infoTree.Origin)
+	}
+	if len(originSeq) < 4 {
+		t.Errorf("expected at least 4 elements in origin sequence, got %d", len(originSeq))
+	}
+	if originSeq[0] != "info" {
+		t.Errorf("expected key_name 'info', got %v", originSeq[0])
 	}
 }
 

--- a/yaml_test.go
+++ b/yaml_test.go
@@ -538,16 +538,19 @@ func TestUnmarshalWithOriginTree(t *testing.T) {
 	if infoTree.Origin == nil {
 		t.Fatal("expected info origin")
 	}
-	// New compact format: []any{key_name, key_line, key_col, nf, ...}
+	// Compact format: []any{file, key_name, key_line, key_col, nf, ...}
 	originSeq, ok := infoTree.Origin.([]any)
 	if !ok {
 		t.Fatalf("expected []any origin, got %T", infoTree.Origin)
 	}
-	if len(originSeq) < 4 {
-		t.Errorf("expected at least 4 elements in origin sequence, got %d", len(originSeq))
+	if len(originSeq) < 5 {
+		t.Errorf("expected at least 5 elements in origin sequence, got %d", len(originSeq))
 	}
-	if originSeq[0] != "info" {
-		t.Errorf("expected key_name 'info', got %v", originSeq[0])
+	if originSeq[0] != "test.yaml" {
+		t.Errorf("expected file 'test.yaml' at index 0, got %v", originSeq[0])
+	}
+	if originSeq[1] != "info" {
+		t.Errorf("expected key_name 'info' at index 1, got %v", originSeq[1])
 	}
 }
 


### PR DESCRIPTION
## Summary
- `extractOrigins` now handles `map[interface{}]interface{}` (produced by yaml3 when YAML maps have non-string keys, e.g. integer HTTP status codes like `200`)
- Updated `yaml_test.go` for new compact sequence format where file is at index 0

## Test plan
- [x] Full test suite passes
- [x] Integer-key maps (HTTP response codes) now correctly have `__origin__` stripped before JSON conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)